### PR TITLE
Create flask interface for working with experiments

### DIFF
--- a/src/interface.py
+++ b/src/interface.py
@@ -1,0 +1,58 @@
+# pylint: disable=broad-exception-raised
+"""
+Functionality that will be used by the flask app
+to interact with the framework
+"""
+
+import uuid
+
+from src.database.models import Experiment, ExperimentStatus
+from src.database.repository import ExperimentRepository
+from src.services import ExperimentService, ExperimentVariantService
+
+
+class ExperimentInterface:
+    """
+    How the server would interact with the experiment
+    """
+
+    @staticmethod
+    def experiment_in_progress(experiment_uuid: uuid.UUID) -> bool:
+        """
+        Check if the experiment is in progress/has ended in a valid state.
+        """
+        return ExperimentService.experiment_in_progress(experiment_uuid)
+
+    @staticmethod
+    def get_variant_name(
+        experiment_uuid: uuid.UUID, participant_uuid: uuid.UUID
+    ) -> str:
+        """
+        Get the variant name for the participant
+        """
+        experiment: Experiment = ExperimentRepository.read(experiment_uuid)
+        if experiment is None:
+            raise Exception("Experiment not found")
+
+        if not ExperimentInterface.experiment_in_progress(experiment_uuid):
+            return "default"
+
+        if ExperimentService.participant_in_experiment(
+            experiment_uuid, participant_uuid
+        ):
+
+            variant_uuid = ExperimentService.get_variant_uuid_for_participant(
+                experiment_uuid, participant_uuid
+            )
+            return ExperimentVariantService.get_variant(variant_uuid).name
+
+        if experiment.experiment_status in [
+            ExperimentStatus.COMPLETED,
+            ExperimentStatus.PAUSED,
+        ]:
+            return "default"
+
+        new_variant_uuid = ExperimentService.add_participant_to_experiment(
+            experiment_uuid, participant_uuid
+        )
+        return ExperimentVariantService.get_variant(new_variant_uuid).name

--- a/src/services.py
+++ b/src/services.py
@@ -119,7 +119,7 @@ class ExperimentService:
             selected_variant.uuid, participant_uuid
         )
 
-        return True
+        return selected_variant.uuid
 
     @staticmethod
     def get_experiment(experiment_uuid: uuid.UUID) -> Optional[Experiment]:
@@ -147,6 +147,21 @@ class ExperimentService:
             if in_variant:
                 return variant_uuid
         return None
+
+    @staticmethod
+    def experiment_in_progress(experiment_uuid: uuid.UUID) -> bool:
+        """
+        Check if the experiment is in progress/has ended in a valid state.
+        """
+        experiment: Experiment = ExperimentRepository.read(experiment_uuid)
+        if experiment is None:
+            raise Exception("Experiment not found")
+
+        return experiment.experiment_status in [
+            ExperimentStatus.RUNNING,
+            ExperimentStatus.PAUSED,
+            ExperimentStatus.COMPLETED,
+        ]
 
     @staticmethod
     def start_experiment(experiment_uuid: uuid.UUID) -> ExperimentStatus:

--- a/tests/test_experiment_services.py
+++ b/tests/test_experiment_services.py
@@ -74,6 +74,30 @@ def test_variant_in_experiment():
     )
 
 
+def test_experiment_in_progress():
+    assert not ExperimentService.experiment_in_progress(test_experiment.experiment_uuid)
+    with pytest.raises(Exception) as e_info:
+        ExperimentService.experiment_in_progress(uuid.uuid4())
+    assert "Experiment not found" in str(e_info.value)
+
+    misc_experiment: Experiment = ExperimentRepository.create(
+        experiment_status=ExperimentStatus.COMPLETED
+    )
+    assert ExperimentService.experiment_in_progress(misc_experiment.experiment_uuid)
+
+    ExperimentRepository.update(
+        misc_experiment.experiment_uuid,
+        experiment_status=ExperimentStatus.PAUSED,
+    )
+    assert ExperimentService.experiment_in_progress(misc_experiment.experiment_uuid)
+
+    ExperimentRepository.update(
+        misc_experiment.experiment_uuid,
+        experiment_status=ExperimentStatus.STOPPED,
+    )
+    assert not ExperimentService.experiment_in_progress(misc_experiment.experiment_uuid)
+
+
 def test_add_variant_to_experiment():
     assert not ExperimentService.add_variant_to_experiment(
         test_experiment.experiment_uuid, mcu_variant.variant_uuid

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,0 +1,85 @@
+# pylint: disable=missing-docstring
+
+import uuid
+
+import pytest
+
+from src.database.models import Experiment, ExperimentStatus
+from src.database.repository import (
+    ExperimentParticipantRepository,
+    ExperimentRepository,
+    ExperimentVariantRepository,
+)
+from src.interface import ExperimentInterface
+from src.services import ExperimentService, ExperimentVariantService, ParticipantService
+
+
+def build_full_basic_experiment() -> dict:
+    participant_uuids = [uuid.uuid4() for _i in range(12)]
+    for p_uuid in participant_uuids:
+        ParticipantService.create_participant(p_uuid)
+
+    variant_names = [
+        "red_no_text",
+        "red_with_text",
+        "blue_no_text",
+        "blue_with_text",
+        "control",
+    ]
+    variants = []
+    for i, v_name in enumerate(variant_names):
+        new_variant = ExperimentVariantRepository.create(
+            name=v_name,
+            description="variations on how to display the button",
+            participants=[
+                participant_uuids[p_index] for p_index in range(12) if p_index % 5 == i
+            ],
+        )
+        variants.append(new_variant)
+
+    experiment = ExperimentRepository.create(
+        name="Button Color + Text Experiment",
+        description="Change the color and text of the button",
+        experiment_variants=[v.variant_uuid for v in variants],
+    )
+
+    return {
+        "experiment": experiment,
+        "participant_uuids": participant_uuids,
+        "variants": variants,
+    }
+
+
+def test_get_variant_name():
+    with pytest.raises(Exception) as e_info:
+        ExperimentInterface.get_variant_name(uuid.uuid4(), uuid.uuid4())
+    assert "Experiment not found" in str(e_info.value)
+
+    stopped_experiment_uuid = uuid.uuid4()
+    _stopped_experiment = ExperimentRepository.create(
+        experiment_uuid=stopped_experiment_uuid,
+        experiment_status=ExperimentStatus.STOPPED,
+    )
+    assert (
+        ExperimentInterface.get_variant_name(stopped_experiment_uuid, uuid.uuid4())
+        == "default"
+    )
+
+    experiment_vals = build_full_basic_experiment()
+    experiment = experiment_vals["experiment"]
+    participant_uuids = experiment_vals["participant_uuids"]
+    variants = experiment_vals["variants"]
+
+    for p_uuid in participant_uuids:
+        assert (
+            ExperimentInterface.get_variant_name(experiment.experiment_uuid, p_uuid)
+            == "default"
+        )
+
+    ExperimentService.start_experiment(experiment.experiment_uuid)
+
+    for i, p_uuid in enumerate(participant_uuids):
+        assert (
+            ExperimentInterface.get_variant_name(experiment.experiment_uuid, p_uuid)
+            == variants[i % 5].name
+        )


### PR DESCRIPTION
The service and repository layers were made to allow for a lot of flexibility, but the interface will more resemble what desired for the test application. Many fields can be expected to exist, as they will be created by someone with the intention of running a experiment, so they should have set everything up beforehand. Can't be mad you can't run a titration experiment when you didn't bring your googles nor your buret.